### PR TITLE
Fix OpenAI period summary schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #
 # Binaries for programs and plugins
+bin/
 *.exe
 *.exe~
 *.dll

--- a/internal/llm/llm_test.go
+++ b/internal/llm/llm_test.go
@@ -300,6 +300,29 @@ func TestValidateStructuredOutputRejectsUnknownFields(t *testing.T) {
 	}
 }
 
+func TestValidateStructuredOutputAcceptsNullOptionalPeriodSummaryCounts(t *testing.T) {
+	t.Parallel()
+
+	output, canonicalJSON, err := ValidateStructuredOutput(
+		prompts.TaskPeriodSummary,
+		[]byte(`{"reportType":"period_summary","headline":"h","overview":"o","keyPoints":[],"riskItems":[],"counts":{"total":1,"open":null,"inProgress":null,"resolved":null,"closed":null}}`),
+	)
+	if err != nil {
+		t.Fatalf("ValidateStructuredOutput returned error: %v", err)
+	}
+
+	periodSummary, ok := output.(PeriodSummaryOutput)
+	if !ok {
+		t.Fatalf("output type = %T, want PeriodSummaryOutput", output)
+	}
+	if periodSummary.Counts.Open != nil || periodSummary.Counts.InProgress != nil || periodSummary.Counts.Resolved != nil || periodSummary.Counts.Closed != nil {
+		t.Fatalf("counts = %#v, want nil optional fields", periodSummary.Counts)
+	}
+	if got, want := string(canonicalJSON), `{"reportType":"period_summary","headline":"h","overview":"o","keyPoints":[],"riskItems":[],"counts":{"total":1}}`; got != want {
+		t.Fatalf("canonicalJSON = %s, want %s", got, want)
+	}
+}
+
 func TestSaveRawResponse(t *testing.T) {
 	t.Parallel()
 

--- a/internal/llm/types.go
+++ b/internal/llm/types.go
@@ -192,7 +192,7 @@ func validatePeriodSummaryOutput(rawJSON []byte) (PeriodSummaryOutput, error) {
 		ReportType: *wire.ReportType,
 		Headline:   *wire.Headline,
 		Overview:   *wire.Overview,
-		KeyPoints:  append([]string(nil), wire.KeyPoints...),
+		KeyPoints:  append(make([]string, 0, len(wire.KeyPoints)), wire.KeyPoints...),
 		RiskItems:  riskItems,
 		Counts: PeriodSummaryCounts{
 			Total:      *wire.Counts.Total,

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -1,6 +1,7 @@
 package prompts
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -227,6 +228,40 @@ func TestManagerRenderRejectsMissingTemplateFiles(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "load system template") {
 		t.Fatalf("Render error = %q, want missing template message", err.Error())
+	}
+}
+
+func TestOutputSchemaJSONPeriodSummaryRequiresAllCountProperties(t *testing.T) {
+	t.Parallel()
+
+	schemaJSON, err := OutputSchemaJSON(TaskPeriodSummary)
+	if err != nil {
+		t.Fatalf("OutputSchemaJSON returned error: %v", err)
+	}
+
+	var schema struct {
+		Properties map[string]struct {
+			Required   []string               `json:"required"`
+			Properties map[string]interface{} `json:"properties"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+
+	counts, ok := schema.Properties["counts"]
+	if !ok {
+		t.Fatalf("schema missing counts property")
+	}
+
+	requiredSet := map[string]struct{}{}
+	for _, name := range counts.Required {
+		requiredSet[name] = struct{}{}
+	}
+	for name := range counts.Properties {
+		if _, ok := requiredSet[name]; !ok {
+			t.Fatalf("counts.required is missing %q", name)
+		}
 	}
 }
 

--- a/internal/prompts/schemas.go
+++ b/internal/prompts/schemas.go
@@ -41,7 +41,7 @@ const periodSummaryOutputSchema = `{
     "counts": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["total"],
+      "required": ["total", "open", "inProgress", "resolved", "closed"],
       "properties": {
         "total": { "type": "integer" },
         "open": { "type": ["integer", "null"] },


### PR DESCRIPTION
## Summary
- fix the period-summary JSON schema for OpenAI structured output by requiring every property in counts
- add regression coverage for the generated schema and null optional count fields
- preserve empty keyPoints as an empty array instead of null in canonical output

## Testing
- go test ./internal/prompts ./internal/llm
- go test ./...
