### PR TITLE
Fix account assignee resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage.*
 *.coverprofile
 profile.cov
 .gocache/
+.tmp/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ bin/
 coverage.*
 *.coverprofile
 profile.cov
+.gocache/
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+SHELL := /bin/bash
+
+APP := backlog-tracker
+BIN_DIR := bin
+BINARY := $(BIN_DIR)/$(APP)
+TMPDIR ?= $(CURDIR)/.tmp
+GOCACHE ?= $(CURDIR)/.gocache
+GOFLAGS ?= -buildvcs=false
+GO_ENV := TMPDIR=$(TMPDIR) GOCACHE=$(GOCACHE) GOFLAGS='$(GOFLAGS)'
+GO := $(GO_ENV) go
+
+.PHONY: help prepare build test vet fmt fmt-check ci clean run-init run-period-summary run-account-report
+
+help:
+	@echo "Targets:"
+	@echo "  make build               Build $(BINARY)"
+	@echo "  make test                Run go test ./..."
+	@echo "  make vet                 Run go vet ./..."
+	@echo "  make fmt                 Format tracked Go files"
+	@echo "  make fmt-check           Fail if formatting is required"
+	@echo "  make ci                  Run fmt-check, vet, and test"
+	@echo "  make clean               Remove local build artifacts"
+	@echo "  make run-init ARGS='...' Run init command"
+	@echo "  make run-period-summary ARGS='...'"
+	@echo "  make run-account-report ARGS='...'"
+
+prepare:
+	@mkdir -p $(BIN_DIR) $(TMPDIR) $(GOCACHE)
+
+build: prepare
+	$(GO) build -o $(BINARY) ./cmd/backlog-tracker
+
+test: prepare
+	$(GO) test ./...
+
+vet: prepare
+	$(GO) vet ./...
+
+fmt:
+	@gofmt -w $$(git ls-files '*.go')
+
+fmt-check:
+	@unformatted="$$(gofmt -l $$(git ls-files '*.go'))"; \
+	if [[ -n "$$unformatted" ]]; then \
+		echo "The following files are not formatted:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
+
+ci: fmt-check vet test
+
+clean:
+	@rm -rf $(BIN_DIR) $(TMPDIR) $(GOCACHE)
+
+run-init: build
+	$(BINARY) init $(ARGS)
+
+run-period-summary: build
+	$(BINARY) period-summary $(ARGS)
+
+run-account-report: build
+	$(BINARY) account-report $(ARGS)

--- a/internal/backlogclient/client.go
+++ b/internal/backlogclient/client.go
@@ -2,6 +2,7 @@ package backlogclient
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,7 +36,9 @@ type Project struct {
 type User struct {
 	ID          int
 	UserID      string
+	UniqueID    string
 	Name        string
+	Keyword     string
 	MailAddress string
 }
 
@@ -95,7 +98,10 @@ type apiClient interface {
 }
 
 type Client struct {
-	api apiClient
+	api        apiClient
+	httpClient *http.Client
+	baseURL    string
+	apiKey     string
 }
 
 func WithHTTPClient(client *http.Client) Option {
@@ -130,7 +136,12 @@ func New(apiKey, baseURL string, options ...Option) (*Client, error) {
 		backlog.OptionHTTPClient(&statusCheckingHTTPClient{client: settings.httpClient}),
 	)
 
-	return &Client{api: client}, nil
+	return &Client{
+		api:        client,
+		httpClient: settings.httpClient,
+		baseURL:    normalizedBaseURL,
+		apiKey:     apiKey,
+	}, nil
 }
 
 func NormalizeBaseURL(raw string) (string, error) {
@@ -184,14 +195,44 @@ func (c *Client) ListProjectUsers(ctx context.Context, projectIDOrKey string) ([
 		return nil, fmt.Errorf("projectIDOrKey is required")
 	}
 
-	users, err := c.api.GetProjectUsersContext(ctx, projectIDOrKey, nil)
+	requestURL, err := c.buildProjectUsersURL(projectIDOrKey)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build project users request for %s: %w", projectIDOrKey, err)
+	}
+
+	response, err := c.httpClient.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("get project users for %s: %w", projectIDOrKey, err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode/100 != 2 {
+		bodySummary, readErr := summarizeErrorBody(response.Body)
+		if readErr != nil {
+			bodySummary = "read error response body failed"
+		}
+		return nil, fmt.Errorf("get project users for %s: %w", projectIDOrKey, &HTTPStatusError{
+			Status:     response.Status,
+			StatusCode: response.StatusCode,
+			Method:     request.Method,
+			URL:        sanitizeURL(request.URL.String()),
+			Body:       bodySummary,
+		})
+	}
+
+	var users []projectUserResponse
+	if err := json.NewDecoder(response.Body).Decode(&users); err != nil {
+		return nil, fmt.Errorf("decode project users for %s: %w", projectIDOrKey, err)
 	}
 
 	mapped := make([]User, 0, len(users))
 	for _, user := range users {
-		mapped = append(mapped, mapUser(user))
+		mapped = append(mapped, user.toUser())
 	}
 	return mapped, nil
 }
@@ -380,6 +421,32 @@ func mapUser(user *backlog.User) User {
 	}
 }
 
+type projectUserResponse struct {
+	ID           int    `json:"id"`
+	UserID       string `json:"userId"`
+	Name         string `json:"name"`
+	Keyword      string `json:"keyword"`
+	MailAddress  string `json:"mailAddress"`
+	NulabAccount *struct {
+		UniqueID string `json:"uniqueId"`
+	} `json:"nulabAccount"`
+}
+
+func (u projectUserResponse) toUser() User {
+	uniqueID := ""
+	if u.NulabAccount != nil {
+		uniqueID = strings.TrimSpace(u.NulabAccount.UniqueID)
+	}
+	return User{
+		ID:          u.ID,
+		UserID:      strings.TrimSpace(u.UserID),
+		UniqueID:    uniqueID,
+		Name:        strings.TrimSpace(u.Name),
+		Keyword:     strings.TrimSpace(u.Keyword),
+		MailAddress: strings.TrimSpace(u.MailAddress),
+	}
+}
+
 func mapStatus(status *backlog.Status) Status {
 	if status == nil {
 		return Status{}
@@ -501,4 +568,23 @@ func summarizeErrorBody(body io.Reader) (string, error) {
 	}
 	summary := strings.Join(strings.Fields(string(data)), " ")
 	return summary, nil
+}
+
+func (c *Client) buildProjectUsersURL(projectIDOrKey string) (string, error) {
+	if strings.TrimSpace(c.baseURL) == "" {
+		return "", fmt.Errorf("backlog base URL is not configured")
+	}
+	if strings.TrimSpace(c.apiKey) == "" {
+		return "", fmt.Errorf("backlog api key is not configured")
+	}
+
+	parsed, err := url.Parse(c.baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse backlog base URL: %w", err)
+	}
+	parsed.Path = path.Join(parsed.Path, "/api/v2/projects", url.PathEscape(strings.TrimSpace(projectIDOrKey)), "users")
+	query := parsed.Query()
+	query.Set("apiKey", c.apiKey)
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
 }

--- a/internal/backlogclient/client.go
+++ b/internal/backlogclient/client.go
@@ -582,7 +582,7 @@ func (c *Client) buildProjectUsersURL(projectIDOrKey string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("parse backlog base URL: %w", err)
 	}
-	parsed.Path = path.Join(parsed.Path, "/api/v2/projects", url.PathEscape(strings.TrimSpace(projectIDOrKey)), "users")
+	parsed.Path = path.Join(parsed.Path, "api/v2/projects", url.PathEscape(strings.TrimSpace(projectIDOrKey)), "users")
 	query := parsed.Query()
 	query.Set("apiKey", c.apiKey)
 	parsed.RawQuery = query.Encode()

--- a/internal/backlogclient/client_test.go
+++ b/internal/backlogclient/client_test.go
@@ -347,6 +347,23 @@ func TestClientClassifiesHTTPFailures(t *testing.T) {
 	}
 }
 
+func TestBuildProjectUsersURLPreservesBaseSubpath(t *testing.T) {
+	t.Parallel()
+
+	client := &Client{
+		baseURL: "https://example.backlog.com/backlog",
+		apiKey:  "test-key",
+	}
+
+	got, err := client.buildProjectUsersURL("PROJ")
+	if err != nil {
+		t.Fatalf("buildProjectUsersURL returned error: %v", err)
+	}
+	if got != "https://example.backlog.com/backlog/api/v2/projects/PROJ/users?apiKey=test-key" {
+		t.Fatalf("buildProjectUsersURL = %q", got)
+	}
+}
+
 func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
 	t.Helper()
 

--- a/internal/backlogclient/client_test.go
+++ b/internal/backlogclient/client_test.go
@@ -93,7 +93,11 @@ func TestClientListsProjectDataIssuesAndComments(t *testing.T) {
 					"id":          10,
 					"userId":      "alice",
 					"name":        "Alice",
+					"keyword":     "Alice Example",
 					"mailAddress": "alice@example.com",
+					"nulabAccount": map[string]any{
+						"uniqueId": "alice-example",
+					},
 				},
 			})
 		case "/api/v2/projects/PROJ/statuses":
@@ -230,6 +234,9 @@ func TestClientListsProjectDataIssuesAndComments(t *testing.T) {
 	}
 	if len(users) != 1 || users[0].UserID != "alice" {
 		t.Fatalf("ListProjectUsers = %#v, want one alice user", users)
+	}
+	if got, want := users[0].UniqueID, "alice-example"; got != want {
+		t.Fatalf("users[0].UniqueID = %q, want %q", got, want)
 	}
 
 	statuses, err := client.ListProjectStatuses(context.Background(), "PROJ")

--- a/internal/backlogclient/collector.go
+++ b/internal/backlogclient/collector.go
@@ -59,10 +59,7 @@ func (c *Collector) ResolveAssignee(ctx context.Context, projectIDOrKey, account
 
 	target := strings.TrimSpace(account)
 	for _, user := range users {
-		if strings.EqualFold(user.UserID, target) {
-			return user, nil
-		}
-		if user.ID > 0 && strconv.Itoa(user.ID) == target {
+		if userMatchesAccount(user, target) {
 			return user, nil
 		}
 	}
@@ -88,4 +85,23 @@ func (c *Collector) CollectAssigneeIssues(ctx context.Context, input AssigneeIss
 		To:             input.To,
 		PageSize:       input.PageSize,
 	})
+}
+
+func userMatchesAccount(user User, target string) bool {
+	if strings.EqualFold(user.UserID, target) {
+		return true
+	}
+	if strings.EqualFold(user.UniqueID, target) {
+		return true
+	}
+	if strings.EqualFold(user.Name, target) {
+		return true
+	}
+	if strings.EqualFold(user.MailAddress, target) {
+		return true
+	}
+	if localPart, _, ok := strings.Cut(user.MailAddress, "@"); ok && strings.EqualFold(localPart, target) {
+		return true
+	}
+	return user.ID > 0 && strconv.Itoa(user.ID) == target
 }

--- a/internal/backlogclient/collector_test.go
+++ b/internal/backlogclient/collector_test.go
@@ -12,7 +12,7 @@ func TestCollectorResolveAssignee(t *testing.T) {
 
 	collector := NewCollector(&fakeCollectorAPI{
 		users: []User{
-			{ID: 10, UserID: "alice", Name: "Alice"},
+			{ID: 10, UserID: "alice", UniqueID: "taketomo-sone", Name: "Alice", MailAddress: "taketomo-sone@example.com"},
 			{ID: 20, UserID: "bob", Name: "Bob"},
 		},
 	})
@@ -31,6 +31,22 @@ func TestCollectorResolveAssignee(t *testing.T) {
 	}
 	if got, want := user.UserID, "bob"; got != want {
 		t.Fatalf("user.UserID = %q, want %q", got, want)
+	}
+
+	user, err = collector.ResolveAssignee(context.Background(), "PROJ", "taketomo-sone")
+	if err != nil {
+		t.Fatalf("ResolveAssignee returned error: %v", err)
+	}
+	if got, want := user.ID, 10; got != want {
+		t.Fatalf("user.ID = %d, want %d", got, want)
+	}
+
+	user, err = collector.ResolveAssignee(context.Background(), "PROJ", "taketomo-sone@example.com")
+	if err != nil {
+		t.Fatalf("ResolveAssignee returned error: %v", err)
+	}
+	if got, want := user.ID, 10; got != want {
+		t.Fatalf("user.ID = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- resolve assignees using the richer Backlog project users response instead of userId alone
- support nulabAccount.uniqueId, email, and email local-part when matching the --account value
- ignore local .gocache artifacts created during local builds

## Testing
- go test ./...
- ./bin/backlog-tracker account-report --account "taketomo-sone" --dry-run
